### PR TITLE
Add Netdata user to docker group if docker is installed

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,3 +31,14 @@
     group: "netdata"
     mode: 0600
   become: yes
+
+- name: "Check installed packages (for Docker)"
+  package_facts:
+    manager: "auto"
+
+- name: Add Netdata user to Docker group
+  user:
+    name: "netdata"
+    groups: "docker"
+    append: "yes"
+  when: ansible_facts.packages | select('search', 'docker') | list | count > 0


### PR DESCRIPTION
Currently on the production netdata server, we don't see the container name, only IDs, which makes it hard to guess, which containers is actually using how many resources.

![image](https://user-images.githubusercontent.com/7010698/74533896-f1afa280-4f32-11ea-8914-773034a316c0.png)

By adding the Netdata user to the Docker group, Netdata is able to read the proc files from Docker and can also resolve the IDs to names:

![image](https://user-images.githubusercontent.com/7010698/74533953-11df6180-4f33-11ea-8f1e-c58375585886.png)

The idea behind the complicated filter in tasks file is, that we could potentially have docker-ee instead of docker-ce installed and Ansible doesn't support direct wildcard matching, so I had to do it this way.