### PR TITLE
Hold Netdata on the installed version

### DIFF
--- a/tasks/install_package_debian.yml
+++ b/tasks/install_package_debian.yml
@@ -33,3 +33,8 @@
   become: yes
   notify:
     - Restart Netdata
+
+- name: Hold Netdata on this version
+  dpkg_selections:
+    name: netdata
+    selection: hold


### PR DESCRIPTION
This holds the Netdata package on Debian systems on the version we pass in the Ansible role. This should prevent accidents where somebody runs `apt update && apt upgrade`, which upgrades Netdata and later we want to deploy our infrastructure pipeline with an older version and it can't downgrade Netdata.