### PR TITLE
Update Netdata to v1.25.0

### DIFF
--- a/tasks/install_package_centos.yml
+++ b/tasks/install_package_centos.yml
@@ -34,7 +34,7 @@
 - name: Install netdata
   yum:
     enablerepo: "netdata_netdata"
-    name: netdata-1.25.0-1.el7.x86_64
+    name: "netdata-{{ netdata_version }}-1.el7.x86_64"
     state: present
     update_cache: true
   become: yes

--- a/tasks/install_package_debian.yml
+++ b/tasks/install_package_debian.yml
@@ -28,7 +28,7 @@
 
 - name: Install netdata
   apt:
-    name: netdata=1.25.0
+    name: "netdata={{ netdata_version }}"
     update_cache: true
   become: yes
   notify:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,12 @@
   tags:
     - always
 
+- name: Gather netdata version for each operating system version
+  include_vars: "{{ item }}"
+  with_first_found:
+    - "{{ ansible_os_family | lower }}{{ ansible_distribution_version|int }}.yml"
+    - main.yml
+
 - include: libuv1_debian_8.yml
   when: ansible_os_family == "Debian" and ansible_distribution_version|int == 8
 

--- a/vars/debian8.yml
+++ b/vars/debian8.yml
@@ -1,0 +1,2 @@
+---
+netdata_version: 1.23.2

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,1 +1,2 @@
 ---
+netdata_version: 1.25.0


### PR DESCRIPTION
This PR updates Netdata for all OS except Debian 8 to v1.25.0.

Netdata doesn't provide new versions anymore for Debian 8, so this PR also contains some logic to fetch the latest version for Debian 8, which is v1.23.2.