### PR TITLE
Update Netdata to v1.29.3

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-netdata_version: 1.28.0
+netdata_version: 1.29.3


### PR DESCRIPTION
This PR updates Netdata to v.1.29.3. This version mainly includes stability and bug fixes, according to Netdata.