### PR TITLE
Bump image versions for role tests

### DIFF
--- a/test/Dockerfile-test-debian10
+++ b/test/Dockerfile-test-debian10
@@ -1,4 +1,4 @@
-FROM simplificator/ansible:debian10
+FROM simplificator/ansible:debian10-2-10
 
 ADD . /etc/ansible/roles/netdata-installation
 

--- a/test/Dockerfile-test-debian8
+++ b/test/Dockerfile-test-debian8
@@ -1,4 +1,4 @@
-FROM simplificator/ansible:debian8
+FROM simplificator/ansible:debian8-2-9
 
 ADD . /etc/ansible/roles/netdata-installation
 

--- a/test/Dockerfile-test-debian9
+++ b/test/Dockerfile-test-debian9
@@ -1,4 +1,4 @@
-FROM simplificator/ansible:debian9
+FROM simplificator/ansible:debian9-2-10
 
 ADD . /etc/ansible/roles/netdata-installation
 

--- a/test/Dockerfile-test-ubuntu
+++ b/test/Dockerfile-test-ubuntu
@@ -1,4 +1,4 @@
-FROM simplificator/ansible:ubuntu1804
+FROM simplificator/ansible:ubuntu1804-2-10
 
 ADD . /etc/ansible/roles/netdata-installation
 


### PR DESCRIPTION
This PR bumps the base images used for testing the role.

* Debian 8 remains at Ansible 2.9
* All others will be upgraded to Ansible 2.10