### PR TITLE
Update Netdata to v1.31.0

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-netdata_version: 1.29.3
+netdata_version: 1.31.0


### PR DESCRIPTION
This PR updates Netdata to the latest version 1.31.0.

https://github.com/netdata/netdata/releases/tag/v1.30.0
https://github.com/netdata/netdata/releases/tag/v1.31.0