### PR TITLE
Improve variable names

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 An Ansible Role that installs a plain version of [Netdata](https://www.netdata.cloud/).
 
-Both our [Netdata client](https://github.com/simplificator/ansible-role-netdata_client) and [Netdata server](https://github.com/simplificator/ansible-role-netdata_server) role use this role as a common base for installing Netdata.
+Both our [Netdata node](https://github.com/simplificator/ansible-role-netdata_node) and [Netdata collector](https://github.com/simplificator/ansible-role-netdata_collector) role use this role as a common base for installing Netdata.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ None.
     - { role: simplificator.netdata_installation }
 ```
 
+## Development
+
+### Variable naming
+
+To ensure that our Netdata roles remain compatible with each other, follow this variable naming convention:
+
+* Role-specific variables are prefixed with the role name (`netdata_installation_` in this case).
+* General variables that are used in multiple roles will be prefixed with just `netdata_`.
+
 ## License
 
 MIT / BSD

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ N/A
 
 ## Role Variables
 
-Available variables are listed below, along with default values (see `defaults/main.yml`):
+The role doesn't require any variable to be set. The following are available for customization:
 
-* `netdata_version`: "1.32.1"
-
-If you plan to send metrics from a client to a server, the role allows to distribute a certificate and a key by setting the variables `netdata_server_certificate` and `netdata_server_certificate_key`.
+* `netdata_installation_version`: The version of Netdata that will be installed.
+* `netdata_installation_certificate`: If you plan to use our collector role, we require to provision a certificate to encrypt traffic between client and collector. Set the certificate with this variable.
+* `netdata_installation_certificate_key`: Key for the mentioned traffic certificate.
 
 ## Dependencies
 

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -7,5 +7,5 @@
     - role: simplificator.netdata_installation
 
   vars:
-    netdata_server_certificate: certificate
-    netdata_server_certificate_key: key
+    netdata_installation_certificate: certificate
+    netdata_installation_certificate_key: key

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,7 @@
 
 - name: Check if installed netdata version differs
   set_fact:
-    is_different_version: "{{ true if ansible_facts.packages['netdata'] is not defined else ansible_facts.packages['netdata'][0].version != netdata_version }}"
+    is_different_version: "{{ true if ansible_facts.packages['netdata'] is not defined else ansible_facts.packages['netdata'][0].version != netdata_installation_version }}"
   changed_when: false
 
 - name: install pre-requisites
@@ -61,7 +61,7 @@
 
 - name: Install netdata
   apt:
-    name: "netdata={{ netdata_version }}"
+    name: "netdata={{ netdata_installation_version }}"
     update_cache: true
   become: yes
   when: is_different_version
@@ -81,7 +81,7 @@
     owner: "netdata"
     group: "netdata"
     mode: 0600
-  when: netdata_server_certificate is defined
+  when: netdata_installation_certificate is defined
   notify:
     - Restart Netdata
   become: yes
@@ -93,7 +93,7 @@
     owner: "netdata"
     group: "netdata"
     mode: 0600
-  when: netdata_server_certificate_key is defined
+  when: netdata_installation_certificate_key is defined
   notify:
     - Restart Netdata
   become: yes

--- a/templates/server_ssl_cert.pem.j2
+++ b/templates/server_ssl_cert.pem.j2
@@ -1,1 +1,1 @@
-{{ netdata_server_certificate }}
+{{ netdata_installation_certificate }}

--- a/templates/server_ssl_key.pem.j2
+++ b/templates/server_ssl_key.pem.j2
@@ -1,1 +1,1 @@
-{{ netdata_server_certificate_key }}
+{{ netdata_installation_certificate_key }}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-netdata_version: 1.32.1
+netdata_installation_version: 1.32.1

--- a/vars/ubuntu_16.yml
+++ b/vars/ubuntu_16.yml
@@ -1,2 +1,2 @@
 ---
-netdata_version: 1.31.0
+netdata_installation_version: 1.31.0


### PR DESCRIPTION
The current variables are named inconsistent. With this PR, I try to clear this up:

* Role-specific variables are prefixed with the role name (`netdata_installation_` in this case).
* General variables that are used in multiple roles will be prefixed with just `netdata_`.