### PR TITLE
Allow to disable connections to Netdata cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The role doesn't require any variable to be set. The following are available for
 * `netdata_installation_version`: The version of Netdata that will be installed.
 * `netdata_installation_certificate`: If you plan to use our collector role, we require to provision a certificate to encrypt traffic between client and collector. Set the certificate with this variable.
 * `netdata_installation_certificate_key`: Key for the mentioned traffic certificate.
+* `netdata_installation_disable_cloud`: Set it to `yes` if your Netdata installation should make a connection to Netdata cloud. Disabled per default.
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,1 +1,2 @@
+netdata_installation_disable_cloud: no
 netdata_installation_use_nightly: no

--- a/files/cloud.d/cloud.conf
+++ b/files/cloud.d/cloud.conf
@@ -1,0 +1,2 @@
+[global]
+enabled = no

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -99,6 +99,25 @@
     - Restart Netdata
   become: yes
 
+- name: Create cloud configuration directory
+  file:
+    path: /var/lib/netdata/cloud.d
+    state: "{{ netdata_installation_disable_cloud | ternary('directory', 'absent') }}"
+    owner: "netdata"
+    group: "netdata"
+    mode: "0770"
+
+- name: Copy cloud.conf
+  copy:
+    src: cloud.d/cloud.conf
+    dest: /var/lib/netdata/cloud.d/cloud.conf
+    owner: "netdata"
+    group: "netdata"
+    mode: "0770"
+  notify:
+    - "Restart Netdata"
+  when: netdata_installation_disable_cloud
+
 - name: Add Netdata user to Docker group
   user:
     name: "netdata"


### PR DESCRIPTION
This code is currently included in both the Netdata node and collector role. However, to simplify it, I move it to the base installation role. The default behaviour is that connections to the cloud are allowed, but a variable can be set to disable it.