### PR TITLE
Put `Add Netdata to Docker group` behind variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The role doesn't require any variable to be set. The following are available for
 * `netdata_installation_certificate`: If you plan to use our collector role, we require to provision a certificate to encrypt traffic between client and collector. Set the certificate with this variable.
 * `netdata_installation_certificate_key`: Key for the mentioned traffic certificate.
 * `netdata_installation_disable_cloud`: Set it to `yes` if your Netdata installation should not make a connection to Netdata cloud.
+* `netdata_installation_monitor_docker`: If set to `yes`, Netdata will be added to the Docker group (if installed) to monitor containers. Disabled per default.
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,3 @@
 netdata_installation_disable_cloud: no
+netdata_installation_monitor_docker: no
 netdata_installation_use_nightly: no

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -124,6 +124,6 @@
     name: "netdata"
     groups: "docker"
     append: "yes"
-  when: ansible_facts.packages['docker-ce'] is defined or ansible_facts.packages['docker-ee'] is defined
+  when: netdata_installation_monitor_docker and (ansible_facts.packages['docker-ce'] is defined or ansible_facts.packages['docker-ee'] is defined)
   notify:
     - Restart Netdata


### PR DESCRIPTION
It can be unexpected when our README states that we do a plain installation of Netdata but add the Netdata user to the Docker group. This feature is now behind a variable.