### PR TITLE
Add Netdata repository with template

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,19 +39,13 @@
     state: present
   become: yes
 
-- name: Add repository
-  apt_repository:
-    repo: deb https://packagecloud.io/netdata/{{ netdata_installation_use_nightly | ternary('netdata-edge', 'netdata') }}/{{ ansible_distribution | lower  }}/ {{ ansible_distribution_release }} main
-    state: present
-    filename: netdata
-  become: yes
-
-- name: Add source repository
-  apt_repository:
-    repo: deb-src https://packagecloud.io/netdata/{{ netdata_installation_use_nightly | ternary('netdata-edge', 'netdata') }}/{{ ansible_distribution | lower  }}/ {{ ansible_distribution_release }} main
-    state: present
-    filename: netdata
-  become: yes
+- name: Add Netdata repository
+  template:
+    src: "netdata.list.j2"
+    dest: "/etc/apt/sources.list.d/netdata.list"
+    owner: "root"
+    group: "root"
+    mode: 644
 
 - name: Unhold Netdata on this version
   dpkg_selections:

--- a/templates/netdata.list.j2
+++ b/templates/netdata.list.j2
@@ -1,0 +1,2 @@
+deb https://packagecloud.io/netdata/{{ netdata_installation_use_nightly | ternary('netdata-edge', 'netdata') }}/{{ ansible_distribution | lower  }}/ {{ ansible_distribution_release }} main
+deb-src https://packagecloud.io/netdata/{{ netdata_installation_use_nightly | ternary('netdata-edge', 'netdata') }}/{{ ansible_distribution | lower  }}/ {{ ansible_distribution_release }} main

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-netdata_installation_version: "{{ netdata_installation_use_nightly | ternary('1.40.0-24-nightly', '1.40.0') }}"
+netdata_installation_version: "{{ netdata_installation_use_nightly | ternary('1.40.0-45-nightly', '1.40.0') }}"


### PR DESCRIPTION
If you previously used the stable version of Netdata and then switched to nightlies, with `apt_repository`, you have both the regular and edge repository in your list. Those two repositories in the list cause troubles when switching back to stable, as edge always has newer versions available for the plugin packages (like the go collector plugin).

Using the template solves this issue, as only one source will be present.