### PR TITLE
Specify plugin list for Netdata

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,7 +56,7 @@
 - name: Install netdata
   apt:
     allow_downgrade: true
-    name: "netdata={{ netdata_installation_version }}"
+    name: "{{ netdata_package_list | join(', ') }}"
     update_cache: true
   become: yes
   when: is_different_version

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,14 @@
 ---
 netdata_installation_version: "{{ netdata_installation_use_nightly | ternary('1.40.0-45-nightly', '1.40.0') }}"
+netdata_package_list:
+  - netdata={{ netdata_installation_version }}
+  - netdata-ebpf-code-legacy={{ netdata_installation_version }}
+  - netdata-plugin-apps={{ netdata_installation_version }}
+  - netdata-plugin-chartsd={{ netdata_installation_version }}
+  - netdata-plugin-debugfs={{ netdata_installation_version }}
+  - netdata-plugin-ebpf={{ netdata_installation_version }}
+  - netdata-plugin-go={{ netdata_installation_version }}
+  - netdata-plugin-nfacct={{ netdata_installation_version }}
+  - netdata-plugin-perf={{ netdata_installation_version }}
+  - netdata-plugin-pythond={{ netdata_installation_version }}
+  - netdata-plugin-slabinfo={{ netdata_installation_version }}


### PR DESCRIPTION
Netdata announced that they split their package into multiple small ones: https://blog.netdata.cloud/split-plugin-packages/

This change resulted in some troubles for us. We like to specify an exact version number for Netdata, but apt always tried to get the latest version, it usually resulted in an error like this:

```
The following packages have unmet dependencies:
 netdata-plugin-apps : Depends: netdata (= 1.40.0-48-nightly) but 1.40.0-45-nightly is to be installed
                       Conflicts: netdata (< 1.40.0-48-nightly) but 1.40.0-45-nightly is to be installed
```

By specifying and locking the version of all packages, the dependency resolution works correctly.

Side-note: It appears that all packages are required for now, contradicting the blog post:

```
$ sudo apt-cache depends netdata
netdata
  ...
  Depends: netdata-plugin-ebpf
  Depends: netdata-plugin-apps
  Depends: netdata-plugin-pythond
  Depends: netdata-plugin-go
  Depends: netdata-plugin-debugfs
  Depends: netdata-plugin-nfacct
  Depends: netdata-plugin-chartsd
  Depends: netdata-plugin-slabinfo
  Depends: netdata-plugin-perf
```