### PR TITLE
Update Netdata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           python-version: "3.x"
 
       - name: Install test dependencies.
-        run: pip3 install ansible molecule molecule-docker
+        run: pip3 install ansible "ansible-core==2.15.2" molecule molecule-docker
 
       - name: Run Molecule tests.
         run: molecule test --scenario-name ${{ matrix.scenario }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
           - ubuntu2204
           - debian10
           - debian11
+          - debian12
         scenario:
           - nightly
           - stable

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,6 +13,7 @@ galaxy_info:
       versions:
         - buster
         - bullseye
+        - bookworm
 
     - name: Ubuntu
       versions:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-netdata_installation_version: "{{ netdata_installation_use_nightly | ternary('1.41.0-318-nightly', '1.41.0') }}"
+netdata_installation_version: "{{ netdata_installation_use_nightly | ternary('1.42.0-43-nightly', '1.42.1') }}"
 netdata_package_list:
   - netdata={{ netdata_installation_version }}
   - netdata-ebpf-code-legacy={{ netdata_installation_version }}


### PR DESCRIPTION
The main purpose of this PR is to update to the latest version v1.42.1.

I also fixed the Molecule pipeline by locking `ansible-core` to `v2.15.2`. I also added Debian 12 to the testing matrix, as we test it already in downstream roles like `netdata_collector`.