### PR TITLE
Use `loose` versioning scheme for updating Netdata nightly version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,7 +21,8 @@
         "netdata_nightly_version: \"(?<currentValue>[\\d\\.\\-]+)-nightly\""
       ],
       "datasourceTemplate": "custom.netdata-nightly",
-      "depNameTemplate": "netdata-nightly"
+      "depNameTemplate": "netdata-nightly",
+      "versioningTemplate": "loose"
     },
     {
       "fileMatch": [


### PR DESCRIPTION
The nightly version in the Ansible role is still set to 1.42.0-122, but 1.42.0-195 is the latest release.

The default versioning scheme for custom stuff in Renovate is `semver`, but it seems that this does play well with the increasing number after the `-`. `loose` apparently also works with quirkier versioning systems. Let's activate this change and see if it has the desired effect.