### PR TITLE
Switch to Netdata repositories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
           - ubuntu2204
           - debian10
           - debian11
+          - debian12
         scenario:
           - nightly
           - stable

--- a/molecule/nightly/molecule.yml
+++ b/molecule/nightly/molecule.yml
@@ -7,7 +7,7 @@ driver:
 
 platforms:
   - name: instance
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian11}-ansible:latest"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian12}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw

--- a/molecule/stable/molecule.yml
+++ b/molecule/stable/molecule.yml
@@ -7,7 +7,7 @@ driver:
 
 platforms:
   - name: instance
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian11}-ansible:latest"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian12}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -61,7 +61,7 @@
   dpkg_selections:
     name: netdata
     selection: install
-  when: is_different_version
+  when: ansible_facts.packages['netdata'] is defined and is_different_version
 
 - name: Install netdata
   apt:
@@ -77,7 +77,6 @@
   dpkg_selections:
     name: netdata
     selection: hold
-  when: is_different_version
 
 - name: Copy SSL certificate to netdata SSL folder
   template:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,8 +24,6 @@
 - name: install pre-requisites
   apt:
     pkg:
-      - debian-archive-keyring
-      - curl
       - gnupg
       - apt-transport-https
     state: present
@@ -33,9 +31,21 @@
     cache_valid_time: 3600
   become: yes
 
+- name: Remove PackageCloud GPG key
+  apt_key:
+    url: "https://packagecloud.io/netdata/netdata/gpgkey"
+    state: absent
+  become: yes
+
+- name: Remove PackageCloud Nigthly GPG key
+  apt_key:
+    url: "https://packagecloud.io/netdata/netdata-edge/gpgkey"
+    state: absent
+  become: yes
+
 - name: Install GPG Key from Netdata
   apt_key:
-    url: "{{ netdata_installation_use_nightly | ternary('https://packagecloud.io/netdata/netdata-edge/gpgkey', 'https://packagecloud.io/netdata/netdata/gpgkey') }}"
+    url: "https://repo.netdata.cloud/netdatabot.gpg.key"
     state: present
   become: yes
 

--- a/templates/netdata.list.j2
+++ b/templates/netdata.list.j2
@@ -1,2 +1,1 @@
-deb https://packagecloud.io/netdata/{{ netdata_installation_use_nightly | ternary('netdata-edge', 'netdata') }}/{{ ansible_distribution | lower  }}/ {{ ansible_distribution_release }} main
-deb-src https://packagecloud.io/netdata/{{ netdata_installation_use_nightly | ternary('netdata-edge', 'netdata') }}/{{ ansible_distribution | lower  }}/ {{ ansible_distribution_release }} main
+deb https://repo.netdata.cloud/repos/{{ netdata_installation_use_nightly | ternary('edge', 'stable') }}/{{ ansible_distribution | lower }}/ {{ ansible_distribution_release | lower }}/

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-netdata_nightly_version: "1.43.0-73-nightly"
+netdata_nightly_version: "1.43.0-343-nightly"
 netdata_stable_version: "1.43.2"
 netdata_installation_version: "{{ netdata_installation_use_nightly | ternary(netdata_nightly_version, netdata_stable_version) }}"
 netdata_package_list:


### PR DESCRIPTION
Netdata offers a custom Debian package repository server. This PR switches to this server.

I also took the opportunity to optimise the installation a bit, and added Debian 12 to the testing matrix.