### PR TITLE
Allow installation of custom netdata versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
         scenario:
           - nightly
           - stable
+          - custom_version
 
     steps:
       - name: Check out the codebase.

--- a/molecule/custom_version/converge.yml
+++ b/molecule/custom_version/converge.yml
@@ -1,0 +1,13 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+
+  roles:
+    - role: simplificator.netdata_installation
+
+  vars:
+    netdata_installation_certificate: certificate
+    netdata_installation_certificate_key: key
+    netdata_installation_disable_cloud: yes
+    netdata_installation_version: "1.43.2"

--- a/molecule/custom_version/molecule.yml
+++ b/molecule/custom_version/molecule.yml
@@ -1,0 +1,24 @@
+---
+dependency:
+  name: galaxy
+
+driver:
+  name: docker
+
+platforms:
+  - name: instance
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian12}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    pre_build_image: true
+
+provisioner:
+  name: ansible
+  playbooks:
+    converge: ${MOLECULE_PLAYBOOK:-converge.yml}
+
+verifier:
+  name: ansible

--- a/molecule/custom_version/verify.yml
+++ b/molecule/custom_version/verify.yml
@@ -1,0 +1,38 @@
+---
+- name: Verify
+  hosts: all
+  tasks:
+    - name: Check content of server certificate
+      lineinfile:
+        dest: /etc/netdata/ssl/cert.pem
+        line: certificate
+      check_mode: true
+      register: presence
+      failed_when: presence.changed
+
+    - name: Check content of server certificate key
+      lineinfile:
+        dest: /etc/netdata/ssl/key.pem
+        line: key
+      check_mode: true
+      register: presence
+      failed_when: presence.changed
+
+    - name: Check Netdata service is running
+      service:
+        name: netdata
+        state: running
+      check_mode: true
+      register: presence
+      failed_when: presence.changed
+
+    - name: "Gather installed packages"
+      package_facts:
+        manager: "auto"
+
+    - name: Check installed Netdata version
+      ansible.builtin.assert:
+        that:
+          - "ansible_facts.packages['netdata'] is defined"
+          - "(ansible_facts.packages['netdata'] | length) == 1"
+          - "ansible_facts.packages['netdata'][0].version == '1.43.2'"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,8 +2,19 @@
 - name: Gather netdata version for each operating system version
   include_vars: "{{ item }}"
   with_first_found:
-    - "{{ ansible_distribution | lower }}_{{ ansible_distribution_version|int }}.yml"
-    - main.yml
+    - "{{ ansible_distribution | lower }}_{{ ansible_distribution_version|int }}_version.yml"
+    - version.yml
+
+- name: Set netdata_installation_version
+  set_fact:
+    netdata_installation_version: "{{ netdata_installation_use_nightly | ternary(netdata_nightly_version, netdata_stable_version) }}"
+  when: netdata_installation_version is undefined
+
+- name: Gather netdata packages for each operating system version
+  include_vars: "{{ item }}"
+  with_first_found:
+    - "{{ ansible_distribution | lower }}_{{ ansible_distribution_version|int }}_packages.yml"
+    - packages.yml
 
 - name: Install Python apt bindings
   apt:

--- a/vars/packages.yml
+++ b/vars/packages.yml
@@ -1,7 +1,3 @@
----
-netdata_nightly_version: "1.44.0-383-nightly"
-netdata_stable_version: "1.44.3"
-netdata_installation_version: "{{ netdata_installation_use_nightly | ternary(netdata_nightly_version, netdata_stable_version) }}"
 netdata_package_list:
   - netdata={{ netdata_installation_version }}
   - netdata-ebpf-code-legacy={{ netdata_installation_version }}

--- a/vars/version.yml
+++ b/vars/version.yml
@@ -1,0 +1,3 @@
+---
+netdata_nightly_version: "1.44.0-383-nightly"
+netdata_stable_version: "1.44.3"


### PR DESCRIPTION
The README states that the variable netdata_installation_version can be
used to install a custom Netdata version, but the previous
implementation of the role hardcoded the value for that variable in
vars/main.yml.