### PR TITLE
Update netdata version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ jobs:
         distro:
           # - ubuntu2204
           # - ubuntu2404
-          # - debian11
-          # - debian12
+          - debian11
+          - debian12
           - debian13
         scenario:
           # - nightly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,10 @@ jobs:
       - name: Set up Python 3.
         uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
+          python-version: "3.12"
 
       - name: Install test dependencies.
-        run: pip3 install ansible molecule molecule-docker "requests<2.32.2"
+        run: pip3 install ansible molecule molecule-plugins[docker] "requests<2.32.2"
 
       - name: Run Molecule tests.
         run: molecule test --scenario-name ${{ matrix.scenario }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install test dependencies.
-        run: pip3 install ansible molecule molecule-plugins[docker] "requests<2.32.2"
+        run: pip3 install "ansible<2.20" molecule molecule-plugins[docker] "requests<2.32.2"
 
       - name: Run Molecule tests.
         run: molecule test --scenario-name ${{ matrix.scenario }}
@@ -44,4 +44,3 @@ jobs:
           PY_COLORS: "1"
           ANSIBLE_FORCE_COLOR: "1"
           MOLECULE_DISTRO: ${{ matrix.distro }}
-          ALLOW_BROKEN_CONDITIONALS: "True"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           - debian12
           - debian13
         scenario:
-          # - nightly
+          - nightly
           - stable
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,21 +17,18 @@ jobs:
     strategy:
       matrix:
         distro:
-          - ubuntu2004
           - ubuntu2204
-          - debian10
+          - ubuntu2404
           - debian11
           - debian12
+          - debian13
         scenario:
           - nightly
           - stable
-        exclude:
-          - distro: debian10
-            scenario: nightly
 
     steps:
       - name: Check out the codebase.
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: "simplificator.netdata_installation"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,13 @@ jobs:
     strategy:
       matrix:
         distro:
-          - ubuntu2204
-          - ubuntu2404
-          - debian11
-          - debian12
+          # - ubuntu2204
+          # - ubuntu2404
+          # - debian11
+          # - debian12
           - debian13
         scenario:
-          - nightly
+          # - nightly
           - stable
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,4 @@ jobs:
           PY_COLORS: "1"
           ANSIBLE_FORCE_COLOR: "1"
           MOLECULE_DISTRO: ${{ matrix.distro }}
+          ALLOW_BROKEN_CONDITIONALS: "True"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install test dependencies.
-        run: pip3 install "ansible>=2.17,<2.18" molecule molecule-plugins[docker] "requests<2.32.2"
+        run: pip3 install "ansible-core>=2.17,<2.18" molecule molecule-plugins[docker] "requests<2.32.2"
 
       - name: Run Molecule tests.
         run: molecule test --scenario-name ${{ matrix.scenario }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,6 @@ jobs:
     strategy:
       matrix:
         distro:
-          # - ubuntu2204
-          # - ubuntu2404
           - debian11
           - debian12
           - debian13

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install test dependencies.
-        run: pip3 install "ansible<2.20" molecule molecule-plugins[docker] "requests<2.32.2"
+        run: pip3 install "ansible>=2.17,<2.18" molecule molecule-plugins[docker] "requests<2.32.2"
 
       - name: Run Molecule tests.
         run: molecule test --scenario-name ${{ matrix.scenario }}

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,12 +11,13 @@ galaxy_info:
   platforms:
     - name: Debian
       versions:
-        - buster
+        - trixie
+        - bookworm
         - bullseye
 
     - name: Ubuntu
       versions:
-        - focal
         - jammy
+        - noble
 
 allow_duplicates: true

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,9 +15,4 @@ galaxy_info:
         - bookworm
         - bullseye
 
-    - name: Ubuntu
-      versions:
-        - jammy
-        - noble
-
 allow_duplicates: true

--- a/molecule/nightly/molecule.yml
+++ b/molecule/nightly/molecule.yml
@@ -7,7 +7,7 @@ driver:
 
 platforms:
   - name: instance
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian12}-ansible:latest"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian13}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw

--- a/molecule/nightly/molecule.yml
+++ b/molecule/nightly/molecule.yml
@@ -22,3 +22,14 @@ provisioner:
 
 verifier:
   name: ansible
+
+scenario:
+  test_sequence:
+    - dependency
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - verify
+    - destroy

--- a/molecule/stable/molecule.yml
+++ b/molecule/stable/molecule.yml
@@ -7,7 +7,7 @@ driver:
 
 platforms:
   - name: instance
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian12}-ansible:latest"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian13}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw

--- a/molecule/stable/molecule.yml
+++ b/molecule/stable/molecule.yml
@@ -22,3 +22,14 @@ provisioner:
 
 verifier:
   name: ansible
+
+scenario:
+  test_sequence:
+    - dependency
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - verify
+    - destroy

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,11 +47,12 @@
     mode: "0755"
   become: yes
 
-- name: Download Netdata GPG key
-  get_url:
-    url: "https://repo.netdata.cloud/netdatabot.gpg.key"
-    dest: /usr/share/keyrings/netdata-archive-keyring.gpg
-    mode: "0644"
+- name: Download and convert Netdata GPG key
+  shell: |
+    curl -fsSL https://repo.netdata.cloud/netdatabot.gpg.key | gpg --dearmor -o /usr/share/keyrings/netdata-archive-keyring.gpg
+    chmod 644 /usr/share/keyrings/netdata-archive-keyring.gpg
+  args:
+    creates: /usr/share/keyrings/netdata-archive-keyring.gpg
   become: yes
 
 - name: Add Netdata repository

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,12 +47,11 @@
     mode: "0755"
   become: yes
 
-- name: Download and convert Netdata GPG key
-  shell: |
-    curl -fsSL https://repo.netdata.cloud/netdatabot.gpg.key | gpg --dearmor -o /usr/share/keyrings/netdata-archive-keyring.gpg
-    chmod 644 /usr/share/keyrings/netdata-archive-keyring.gpg
-  args:
-    creates: /usr/share/keyrings/netdata-archive-keyring.gpg
+- name: Download Netdata GPG key in ASCII format
+  get_url:
+    url: "https://repo.netdata.cloud/netdatabot.gpg.key"
+    dest: /usr/share/keyrings/netdata-archive-keyring.asc
+    mode: "0644"
   become: yes
 
 - name: Add Netdata repository

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,7 @@
 
 - name: Check if installed netdata version differs
   set_fact:
-    is_different_version: "{{ true if ansible_facts.packages['netdata'] is not defined else ansible_facts.packages['netdata'][0].version != netdata_installation_version }}"
+    is_different_version: "{{ true if ansible_facts.packages['netdata'] is not defined else (netdata_installation_use_nightly or ansible_facts.packages['netdata'][0].version != netdata_installation_version) }}"
   changed_when: false
 
 - name: install pre-requisites
@@ -82,6 +82,7 @@
   dpkg_selections:
     name: netdata
     selection: hold
+  when: not netdata_installation_use_nightly
 
 - name: Copy SSL certificate to netdata SSL folder
   template:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,22 +31,27 @@
     cache_valid_time: 3600
   become: yes
 
-- name: Remove PackageCloud GPG key
-  apt_key:
-    url: "https://packagecloud.io/netdata/netdata/gpgkey"
+- name: Remove old PackageCloud GPG keys (if present)
+  file:
+    path: "{{ item }}"
     state: absent
+  loop:
+    - /etc/apt/trusted.gpg.d/netdata.gpg
+    - /etc/apt/trusted.gpg.d/netdata-edge.gpg
   become: yes
 
-- name: Remove PackageCloud Nigthly GPG key
-  apt_key:
-    url: "https://packagecloud.io/netdata/netdata-edge/gpgkey"
-    state: absent
+- name: Create keyrings directory
+  file:
+    path: /usr/share/keyrings
+    state: directory
+    mode: "0755"
   become: yes
 
-- name: Install GPG Key from Netdata
-  apt_key:
+- name: Download Netdata GPG key
+  get_url:
     url: "https://repo.netdata.cloud/netdatabot.gpg.key"
-    state: present
+    dest: /usr/share/keyrings/netdata-archive-keyring.gpg
+    mode: "0644"
   become: yes
 
 - name: Add Netdata repository

--- a/templates/netdata.list.j2
+++ b/templates/netdata.list.j2
@@ -1,1 +1,1 @@
-deb [signed-by=/usr/share/keyrings/netdata-archive-keyring.gpg] https://repo.netdata.cloud/repos/{{ netdata_installation_use_nightly | ternary('edge', 'stable') }}/{{ ansible_distribution | lower }}/ {{ ansible_distribution_release | lower }}/
+deb [signed-by=/usr/share/keyrings/netdata-archive-keyring.asc] https://repo.netdata.cloud/repos/{{ netdata_installation_use_nightly | ternary('edge', 'stable') }}/{{ ansible_distribution | lower }}/ {{ ansible_distribution_release | lower }}/

--- a/templates/netdata.list.j2
+++ b/templates/netdata.list.j2
@@ -1,1 +1,1 @@
-deb https://repo.netdata.cloud/repos/{{ netdata_installation_use_nightly | ternary('edge', 'stable') }}/{{ ansible_distribution | lower }}/ {{ ansible_distribution_release | lower }}/
+deb [signed-by=/usr/share/keyrings/netdata-archive-keyring.gpg] https://repo.netdata.cloud/repos/{{ netdata_installation_use_nightly | ternary('edge', 'stable') }}/{{ ansible_distribution | lower }}/ {{ ansible_distribution_release | lower }}/

--- a/vars/debian_10.yml
+++ b/vars/debian_10.yml
@@ -1,1 +1,0 @@
-netdata_stable_version: "1.46.1"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-netdata_stable_version: "2.8.1"
+netdata_stable_version: "2.8.2"
 netdata_installation_version: "{{ netdata_installation_use_nightly | ternary('', netdata_stable_version) }}"
 netdata_version_suffix: "{{ '' if netdata_installation_use_nightly else '=' + netdata_installation_version }}"
 netdata_package_list:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,6 +1,6 @@
 ---
-netdata_nightly_version: "1.46.0-194-nightly"
-netdata_stable_version: "1.46.2"
+netdata_nightly_version: "2.8.0-6-nightly"
+netdata_stable_version: "2.8.1"
 netdata_installation_version: "{{ netdata_installation_use_nightly | ternary(netdata_nightly_version, netdata_stable_version) }}"
 netdata_package_list:
   - netdata={{ netdata_installation_version }}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,15 +1,15 @@
 ---
-netdata_nightly_version: "2.8.0-6-nightly"
 netdata_stable_version: "2.8.1"
-netdata_installation_version: "{{ netdata_installation_use_nightly | ternary(netdata_nightly_version, netdata_stable_version) }}"
+netdata_installation_version: "{{ netdata_installation_use_nightly | ternary('', netdata_stable_version) }}"
+netdata_version_suffix: "{{ '' if netdata_installation_use_nightly else '=' + netdata_installation_version }}"
 netdata_package_list:
-  - netdata={{ netdata_installation_version }}
-  - netdata-plugin-apps={{ netdata_installation_version }}
-  - netdata-plugin-chartsd={{ netdata_installation_version }}
-  - netdata-plugin-debugfs={{ netdata_installation_version }}
-  - netdata-plugin-ebpf={{ netdata_installation_version }}
-  - netdata-plugin-go={{ netdata_installation_version }}
-  - netdata-plugin-nfacct={{ netdata_installation_version }}
-  - netdata-plugin-perf={{ netdata_installation_version }}
-  - netdata-plugin-pythond={{ netdata_installation_version }}
-  - netdata-plugin-slabinfo={{ netdata_installation_version }}
+  - netdata{{ netdata_version_suffix }}
+  - netdata-plugin-apps{{ netdata_version_suffix }}
+  - netdata-plugin-chartsd{{ netdata_version_suffix }}
+  - netdata-plugin-debugfs{{ netdata_version_suffix }}
+  - netdata-plugin-ebpf{{ netdata_version_suffix }}
+  - netdata-plugin-go{{ netdata_version_suffix }}
+  - netdata-plugin-nfacct{{ netdata_version_suffix }}
+  - netdata-plugin-perf{{ netdata_version_suffix }}
+  - netdata-plugin-pythond{{ netdata_version_suffix }}
+  - netdata-plugin-slabinfo{{ netdata_version_suffix }}


### PR DESCRIPTION
- Updated CI workflow to include Ubuntu 24.04 and Debian 13, while removing Debian 10.
- Changed Docker images in Molecule configurations to use Debian 13.
- Removed deprecated vars/debian_10.yml file.
- Updated Netdata versions in vars/main.yml to 2.8.0-6-nightly and 2.8.1 for stable.