### PR TITLE
Bump netdata stable version to 2.9.0

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-netdata_stable_version: "2.8.4"
+netdata_stable_version: "2.9.0"
 netdata_installation_version: "{{ netdata_installation_use_nightly | ternary('', netdata_stable_version) }}"
 netdata_version_suffix: "{{ '' if netdata_installation_use_nightly else '=' + netdata_installation_version }}"
 netdata_package_list:


### PR DESCRIPTION
## Summary

- Bumps `netdata_stable_version` from `2.8.4` to `2.9.0`

## Why

The netdata apt repository now ships `netdata-dashboard`, `netdata-plugin-otel`, and `netdata-user` at version 2.9.0, which explicitly conflict with `netdata < 2.9.0`. This makes it impossible to install 2.8.4 via apt, breaking CI.

## Test plan

- [x] CI passes on all distros (ubuntu2204, ubuntu2404, debian11, debian12, debian13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)